### PR TITLE
Add Nord Filament theme and configure Vite build entry

### DIFF
--- a/resources/assets/core/css/themes/filament-nord.css
+++ b/resources/assets/core/css/themes/filament-nord.css
@@ -1,0 +1,264 @@
+/**
+ * Filament Nord Theme
+ *
+ * Provides a Nord-inspired design language for Filament components
+ * using Tailwind CSS v4 utilities and tokens.
+ */
+
+@import "tailwindcss";
+
+@theme {
+    --color-secondary-50: #E3E9F0;
+    --color-secondary-100: #D1D7E0;
+    --color-secondary-200: #A7B1C5;
+    --color-secondary-300: #8C9AB3;
+    --color-secondary-400: #71829B;
+    --color-secondary-500: #5E81AC;
+    --color-secondary-600: #527397;
+    --color-secondary-700: #466582;
+    --color-secondary-800: #3A576D;
+    --color-secondary-900: #2E4958;
+    --color-secondary-950: #223B43;
+
+    /* Polar Night: Used for dark backgrounds and text */
+    --color-polarnight-50: #e5e9f0;
+    --color-polarnight-100: #d1d7e0;
+    --color-polarnight-200: #a7b1c5;
+    --color-polarnight-300: #8c9ab3;
+    --color-polarnight-400: #71829b;
+    --color-polarnight-500: #4c566a;
+    --color-polarnight-600: #434c5e;
+    --color-polarnight-700: #3b4252;
+    --color-polarnight-800: #2e3440;
+    --color-polarnight-900: #232831;
+    --color-polarnight-950: #1b2027;
+
+    /* Snow Storm: Used for light backgrounds and text */
+    --color-snowstorm-400: #d8dee9;
+    --color-snowstorm-500: #e5e9f0;
+    --color-snowstorm-600: #eceff4;
+
+    /* Frost: Used for primary and secondary accents */
+    --color-frost-400: #8fbcbb;
+    --color-frost-500: #88c0d0;
+    --color-frost-600: #81a1c1;
+    --color-frost-700: #5e81ac;
+
+    /* Aurora: Used for success, warning, etc. */
+    --color-aurora-danger: #bf616a;
+    --color-aurora-warning: #ebcb8b;
+    --color-aurora-success: #a3be8c;
+    --color-aurora-info: #81a1c1;
+    --color-aurora-purple: #b48ead;
+    --color-aurora-orange: #d08770;
+
+    /* Semantic color mapping to Nord palette */
+    --color-danger: var(--color-aurora-danger);
+    --color-warning: var(--color-aurora-warning);
+    --color-success: var(--color-aurora-success);
+    --color-info: var(--color-aurora-info);
+
+    /* Main theme colors from the Frost palette */
+    --color-primary: var(--color-frost-500);
+    --color-primary-100: #E5F3F7;
+    --color-primary-200: #CCE7EF;
+    --color-primary-300: #B3DBE7;
+    --color-primary-400: var(--color-frost-400);
+    --color-primary-500: var(--color-frost-500);
+    --color-primary-600: var(--color-frost-600);
+    --color-primary-700: var(--color-frost-700);
+    --color-primary-800: var(--color-frost-700);
+    --color-primary-900: var(--color-polarnight-800);
+    --color-primary-950: var(--color-polarnight-900);
+
+    /* General UI colors from Polarnight & Snowstorm */
+    --color-background-light: var(--color-snowstorm-500);
+    --color-background-dark: var(--color-polarnight-800);
+    --color-surface-light: var(--color-snowstorm-600);
+    --color-surface-dark: var(--color-polarnight-700);
+    --color-text-dark: var(--color-polarnight-600);
+    --color-text-light: var(--color-snowstorm-500);
+    --color-text-subtle: var(--color-polarnight-500);
+    --color-border-light: var(--color-snowstorm-400);
+    --color-border-dark: var(--color-polarnight-700);
+}
+
+.fi-layout {
+    @apply bg-[var(--color-background-light)] dark:bg-[var(--color-background-dark)];
+}
+
+.fi-topbar nav, .fi-sidebar-header {
+    @apply bg-[var(--color-background-light)] dark:bg-[var(--color-background-dark)];
+}
+
+.fi-btn-color-primary {
+    @apply bg-[var(--color-primary-500)];
+}
+
+.fi-ta-ctn, .fi-ta-ctn .fi-ta-ctn-with-header {
+    @apply dark:bg-[var(--color-surface-dark)];
+}
+
+.fi-ta-table thead tr {
+    @apply bg-[var(--color-surface-light)] dark:bg-[var(--color-surface-dark)];
+}
+
+.fi-sidebar-item-label, .fi-topbar-item-label {
+    @apply dark:text-gray-400;
+}
+
+.fi-sidebar-item-active a svg, .fi-topbar-item-active a svg {
+    @apply text-primary-800;
+}
+
+.fi-sidebar-item-active a span, .fi-topbar-item-active a span {
+    @apply text-primary-800 dark:text-primary-400;
+}
+
+.fi-sidebar-item .fi-sidebar-item-button, .fi-topbar-item .fi-topbar-item-button {
+    @apply rounded-lg hover:bg-[var(--color-snowstorm-400)] dark:hover:bg-white/5;
+}
+
+.fi-sidebar-item-active .fi-sidebar-item-button, .fi-topbar-item-active .fi-topbar-item-button {
+    @apply rounded-lg bg-[var(--color-snowstorm-600)] dark:focus-visible:bg-white/5 dark:bg-white/5;
+}
+
+.fi-fo-field-wrp-label span {
+    @apply text-[var(--color-polarnight-500)];
+}
+
+.fi-breadcrumbs-item-label {
+    @apply text-[var(--color-polarnight-500)];
+}
+
+.fi-header-heading, .fi-ta-header-cell-label, .fi-btn-color-gray span {
+    @apply text-[var(--color-polarnight-600)] dark:text-[var(--color-snowstorm-500)];
+}
+
+.fi-body {
+    @apply bg-[var(--color-snowstorm-500)] dark:bg-polarnight-900;
+}
+
+.fi-input-wrp {
+    @apply ring-1 ring-[var(--color-snowstorm-400)] dark:ring-white/20;
+}
+
+.fi-tabs-item-active {
+    @apply bg-primary-100;
+}
+
+.fi-tabs-item-active span {
+    @apply !text-secondary-900;
+}
+
+.fi-ta-ctn {
+    @apply shadow-md rounded-2xl border-none ring-0 dark:ring-1 divide-gray-100 dark:divide-white/20;
+    /*rounded-none*/
+}
+
+.fi-section, .fi-wi-stats-overview-stat, .fi-ta-ctn, .fi-tenant-menu, .fi-dropdown-panel {
+    @apply border border-transparent dark:bg-secondary-900;
+}
+
+.dark .fi-section, .dark .fi-wi-stats-overview-stat, .dark .fi-ta-ctn, .dark .fi-tenant-menu, .dark .fi-dropdown-panel {
+    background: linear-gradient(var(--color-polarnight-800), var(--color-polarnight-700)),
+    linear-gradient(to right, var(--color-secondary-800), var(--color-polarnight-700));
+    background-clip: padding-box, border-box;
+    background-origin: border-box;
+}
+
+.fi-section, .fi-wi-stats-overview-stat {
+    @apply shadow-md rounded-2xl border-none ring-0 dark:ring-1;
+}
+
+.fi-topbar-item-active a, .fi-topbar-item-active button {
+    @apply bg-secondary-500 hover:bg-secondary-400 dark:bg-primary-500 dark:text-secondary-500 dark:hover:bg-primary-400;
+}
+
+.fi-topbar-item-active svg {
+    @apply dark:text-secondary-500;
+}
+
+.fi-topbar .fi-tenant-menu {
+    @apply lg:!hidden;
+}
+
+.fi-tenant-menu {
+    @apply rounded-lg mt-4;
+}
+
+.fi-fo-field-wrp-error-message {
+    @apply text-[var(--color-aurora-danger)] dark:text-[var(--color-aurora-orange)];
+}
+
+.fi-invalid {
+    @apply ring-[var(--color-aurora-danger)] dark:ring-[var(--color-aurora-orange)];
+}
+
+.fi-global-search-field .fi-input-wrp, .fi-ta-search-field .fi-input-wrp {
+    @apply rounded-full bg-[var(--color-snowstorm-500)] dark:bg-gray-900;
+}
+
+.fi-global-search-field .fi-input-wrp {
+    @apply ring-4 ring-white dark:ring-gray-800;
+}
+
+.fi-global-search-field .fi-input-wrp .fi-input-wrp-prefix {
+    @apply bg-white dark:bg-gray-800 rounded-full ps-2 mr-2;
+}
+
+.fi-btn:not(.fi-btn-group .fi-btn) {
+    @apply rounded-full;
+}
+
+.fi-btn-group > .fi-btn:first-of-type {
+    @apply rounded-s-full;
+}
+
+.fi-btn-group > .fi-btn:last-of-type {
+    @apply rounded-e-full;
+}
+
+.fi-btn-group {
+    @apply rounded-full;
+}
+
+.fi-wi-widget .fi-section, .fi-wi-stats-overview-stat {
+    @apply dark:ring-gray-700 dark:hover:text-white/70 dark:hover:ring-gray-500;
+}
+
+.fi-ta-toggle > div.fi-color-custom, .fi-fo-toggle.fi-color-custom {
+    @apply bg-primary-500;
+}
+
+.fi-ta-toggle > div.fi-color-gray, .fi-fo-toggle.fi-color-gray {
+    @apply bg-gray-200;
+}
+
+.fi-badge {
+    @apply rounded-xl;
+}
+
+.fi-fo-field-wrp-helper-text {
+    @apply text-gray-500 dark:text-gray-300;
+}
+
+.fi-tabs-item-active span {
+    @apply dark:!text-gray-100;
+}
+
+.fi-sidebar-item-button .fi-badge, .fi-topbar-item-button .fi-badge {
+    @apply bg-primary-300 dark:bg-primary-200;
+}
+
+.fi-sidebar-item-button .fi-badge span span, .fi-topbar-item-button .fi-badge span span {
+    @apply text-gray-700;
+}
+
+.fi-input {
+    @apply disabled:!bg-gray-50 dark:disabled:!bg-gray-800;
+}
+
+.fi-btn.fi-color-primary .fi-btn-label {
+    @apply text-primary-950;
+}

--- a/resources/assets/invoiceplane/css/.gitignore
+++ b/resources/assets/invoiceplane/css/.gitignore
@@ -1,4 +1,5 @@
 *
 !custom.css
 !custom-pdf.css
+!style-tailwind.css
 !.gitignore

--- a/resources/assets/invoiceplane/css/style-tailwind.css
+++ b/resources/assets/invoiceplane/css/style-tailwind.css
@@ -1,0 +1,737 @@
+/**
+ * InvoicePlane Styles - Default Theme
+ * 
+ * This is the default InvoicePlane stylesheet that combines:
+ * 1. Tailwind CSS base, components, and utilities
+ * 2. Bootstrap-compatible classes implemented with Tailwind
+ * 3. InvoicePlane custom styles
+ */
+
+@import "tailwindcss";
+
+/* ================================
+ * InvoicePlane Color Variables
+ * Based on Bootstrap default palette
+ * ================================ */
+:root {
+  /* Gray scale - Standard Bootstrap */
+  --gray-base: #000;
+  --gray-darker: #222;
+  --gray-dark: #333;
+  --gray: #555;
+  --gray-light: #777;
+  --gray-lighter: #eee;
+  --gray-lightest: #f9f9f9;
+
+  /* Brand colors - InvoicePlane palette */
+  --brand-primary: #2C8EDD;
+  --brand-success: #5cb85c;
+  --brand-info: #5bc0de;
+  --brand-warning: #f0ad4e;
+  --brand-danger: #d9534f;
+
+  /* Dark variants for alerts */
+  --dark-success: #3c763d;
+  --dark-info: #31708f;
+  --dark-warning: #8a6d3b;
+  --dark-danger: #a94442;
+
+  /* Scaffolding */
+  --body-bg: #fff;
+  --text-color: #333;
+  --link-color: #2C8EDD;
+  --link-hover-color: #1a6bb8;
+}
+
+@layer components {
+  /* ================================
+   * BUTTONS
+   * ================================ */
+  
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25rem;
+    border-radius: 0.25rem;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background-color 150ms ease-in-out, border-color 150ms ease-in-out;
+  }
+  
+  .btn-primary {
+    background-color: var(--brand-primary);
+    color: white;
+    border-color: #2579c4;
+  }
+  
+  .btn-primary:hover {
+    background-color: #2579c4;
+    border-color: #1e68a8;
+  }
+  
+  .btn-default {
+    background-color: white;
+    color: var(--gray-darker);
+    border-color: #ccc;
+  }
+  
+  .btn-default:hover {
+    background-color: var(--gray-lighter);
+    border-color: #adadad;
+  }
+  
+  .btn-success {
+    background-color: var(--brand-success);
+    color: white;
+    border-color: #4cae4c;
+  }
+  
+  .btn-success:hover {
+    background-color: #449d44;
+    border-color: #398439;
+  }
+  
+  .btn-info {
+    background-color: var(--brand-info);
+    color: white;
+    border-color: #46b8da;
+  }
+  
+  .btn-info:hover {
+    background-color: #31b0d5;
+    border-color: #269abc;
+  }
+  
+  .btn-warning {
+    background-color: var(--brand-warning);
+    color: white;
+    border-color: #eea236;
+  }
+  
+  .btn-warning:hover {
+    background-color: #ec971f;
+    border-color: #d58512;
+  }
+  
+  .btn-danger {
+    background-color: var(--brand-danger);
+    color: white;
+    border-color: #d43f3a;
+  }
+  
+  .btn-danger:hover {
+    background-color: #c9302c;
+    border-color: #ac2925;
+  }
+  
+  /* Button sizes */
+  .btn-xs {
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+  
+  .btn-sm {
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+  
+  .btn-lg {
+    padding: 0.625rem 1rem;
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+  
+  .btn-block {
+    width: 100%;
+    display: block;
+  }
+  
+  /* ================================
+   * FORMS
+   * ================================ */
+  
+  .form-group {
+    margin-bottom: 1rem;
+  }
+  
+  .form-control {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.25;
+    color: var(--gray);
+    background-color: white;
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    transition: border-color 150ms ease-in-out, box-shadow 150ms ease-in-out;
+  }
+  
+  .form-control:focus {
+    border-color: #66afe9;
+    outline: none;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  }
+  
+  .input-sm {
+    height: 30px;
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+  
+  .input-lg {
+    height: 46px;
+    padding: 0.625rem 1rem;
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+  
+  .input-group {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+  }
+  
+  .input-group-addon {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: normal;
+    line-height: 1.25;
+    color: var(--gray);
+    text-align: center;
+    background-color: var(--gray-lighter);
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    white-space: nowrap;
+  }
+  
+  label {
+    display: inline-block;
+    max-width: 100%;
+    margin-bottom: 0.25rem;
+    font-weight: normal;
+  }
+  
+  /* ================================
+   * TABLES
+   * ================================ */
+  
+  .table {
+    width: 100%;
+    margin-bottom: 1.25rem;
+    border-collapse: collapse;
+  }
+  
+  .table > thead > tr > th,
+  .table > tbody > tr > th,
+  .table > tfoot > tr > th,
+  .table > thead > tr > td,
+  .table > tbody > tr > td,
+  .table > tfoot > tr > td {
+    padding: 0.5rem;
+    line-height: 1.25;
+    border-top: 1px solid #ddd;
+  }
+  
+  .table > thead > tr > th {
+    border-bottom: 2px solid #ddd;
+    vertical-align: bottom;
+  }
+  
+  .table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: var(--gray-lightest);
+  }
+  
+  .table-bordered {
+    border: 1px solid #ddd;
+  }
+  
+  .table-bordered > thead > tr > th,
+  .table-bordered > tbody > tr > th,
+  .table-bordered > tfoot > tr > th,
+  .table-bordered > thead > tr > td,
+  .table-bordered > tbody > tr > td,
+  .table-bordered > tfoot > tr > td {
+    border: 1px solid #ddd;
+  }
+  
+  .table-hover > tbody > tr:hover {
+    background-color: #f5f5f5;
+  }
+  
+  /* ================================
+   * ALERTS
+   * ================================ */
+  
+  .alert {
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.25rem;
+    border: 1px solid;
+    border-radius: 0.25rem;
+  }
+  
+  .alert-success {
+    color: var(--dark-success);
+    background-color: #dff0d8;
+    border-color: #d6e9c6;
+  }
+  
+  .alert-info {
+    color: var(--dark-info);
+    background-color: #d9edf7;
+    border-color: #bce8f1;
+  }
+  
+  .alert-warning {
+    color: var(--dark-warning);
+    background-color: #fcf8e3;
+    border-color: #faebcc;
+  }
+  
+  .alert-danger {
+    color: var(--dark-danger);
+    background-color: #f2dede;
+    border-color: #ebccd1;
+  }
+  
+  /* ================================
+   * PANELS
+   * ================================ */
+  
+  .panel {
+    margin-bottom: 1.25rem;
+    background-color: white;
+    border: 1px solid #ddd;
+    border-radius: 0.25rem;
+  }
+  
+  .panel-body {
+    padding: 1rem;
+  }
+  
+  .panel-heading {
+    padding: 0.625rem 1rem;
+    border-bottom: 1px solid #ddd;
+  }
+  
+  .panel-default > .panel-heading {
+    color: var(--gray-darker);
+    background-color: #f5f5f5;
+    border-color: #ddd;
+  }
+  
+  /* ================================
+   * UTILITIES
+   * ================================ */
+  
+  .pull-left {
+    float: left;
+  }
+  
+  .pull-right {
+    float: right;
+  }
+  
+  .text-left {
+    text-align: left;
+  }
+  
+  .text-center {
+    text-align: center;
+  }
+  
+  .text-right {
+    text-align: right;
+  }
+  
+  .text-muted {
+    color: #777;
+  }
+  
+  .clearfix::after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+  
+  /* ================================
+   * PAGINATION
+   * ================================ */
+  
+  .pagination {
+    display: flex;
+    list-style: none;
+    border-radius: 0.25rem;
+    padding-left: 0;
+    margin-bottom: 1.25rem;
+  }
+  
+  .pagination > li > a,
+  .pagination > li > span {
+    position: relative;
+    float: left;
+    padding: 0.375rem 0.75rem;
+    line-height: 1.25;
+    color: var(--brand-primary);
+    text-decoration: none;
+    background-color: white;
+    border: 1px solid #ddd;
+    margin-left: -1px;
+  }
+  
+  .pagination > li:first-child > a,
+  .pagination > li:first-child > span {
+    margin-left: 0;
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
+  }
+  
+  .pagination > li:last-child > a,
+  .pagination > li:last-child > span {
+    border-top-right-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+  }
+  
+  .pagination > li > a:hover {
+    background-color: var(--gray-lighter);
+    border-color: #ddd;
+  }
+  
+  .pagination > .active > a {
+    z-index: 10;
+    color: white;
+    background-color: var(--brand-primary);
+    border-color: var(--brand-primary);
+    cursor: default;
+  }
+}
+
+/* Import Tailwind CSS and Bootstrap-compatible classes */
+
+/* Import third-party component styles that don't need refactoring */
+@import "bootstrap-datepicker/dist/css/bootstrap-datepicker3.css";
+@import "font-awesome/css/font-awesome.css";
+@import "dropzone/dist/dropzone.css";
+@import "select2/dist/css/select2.css";
+
+/* Import existing custom CSS files */
+@import "../../core/css/custom.css";
+
+/* ================================
+ * InvoicePlane Core Styles
+ * Using Tailwind's @layer to add custom components
+ * ================================ */
+
+@layer components {
+  /* Fix for Bootstrap 3 collapse table behavior */
+  table.collapse.in {
+    display: table;
+  }
+  
+  /* Alert fix for CI core paragraph */
+  .alert-dismissible p {
+    display: inline;
+  }
+  
+  /* Base HTML styles */
+  html {
+    min-height: 100vh;
+  }
+  
+  body {
+    min-height: 100vh;
+    overflow-x: hidden;
+    overflow-y: scroll;
+  }
+  
+  img {
+    vertical-align: middle;
+    max-width: 100%;
+  }
+  
+  h1, h2, h3, h4, h5, h6 {
+    margin: 0;
+  }
+  
+  /* Text ellipsis helpers */
+  .dib {
+    display: inline-block;
+  }
+  
+  .db {
+    display: block;
+  }
+  
+  .te {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 160px;
+  }
+  
+  /* Variable width text ellipsis */
+  .te.te-1 { max-width: 10vw; }
+  .te.te-2 { max-width: 20vw; }
+  .te.te-3 { max-width: 30vw; }
+  .te.te-4 { max-width: 40vw; }
+  .te.te-5 { max-width: 50vw; }
+  .te.te-6 { max-width: 60vw; }
+  .te.te-7 { max-width: 70vw; }
+  .te.te-8 { max-width: 80vw; }
+  .te.te-9 { max-width: 90vw; }
+  
+  /* Dropzone mobile-first */
+  #previews .name {
+    word-wrap: anywhere;
+  }
+  
+  /* Forms */
+  form {
+    margin: 0;
+  }
+  
+  fieldset {
+    border-radius: 0.25rem;
+    border: 1px solid #ddd;
+    margin-bottom: 1rem;
+    padding: 1rem;
+  }
+  
+  fieldset legend {
+    padding: 0 1rem;
+    font-size: 1.125rem;
+    width: auto;
+    border: none;
+    margin: 0;
+  }
+  
+  label {
+    font-weight: normal;
+  }
+  
+  textarea {
+    resize: vertical;
+  }
+  
+  .discount-field {
+    float: right;
+    max-width: 40%;
+    margin-left: 0.625rem;
+  }
+  
+  .discount-field .input-sm {
+    height: auto;
+    padding: 0.125rem 0.25rem;
+  }
+  
+  .discount-field .input-group-addon {
+    min-width: 20px;
+  }
+  
+  .optional {
+    float: right;
+    font-size: small;
+    color: #777;
+  }
+  
+  /* Enhanced table styles */
+  .table {
+    margin: 0 0 1rem;
+    font-size: 0.875rem;
+  }
+  
+  .table.no-margin {
+    margin: 0;
+  }
+  
+  .table td {
+    vertical-align: middle !important;
+  }
+  
+  .table tr.bold-border td {
+    border-bottom-width: 2px;
+  }
+  
+  .table.items td {
+    min-width: 150px;
+    max-width: 300px;
+    vertical-align: top !important;
+  }
+  
+  .table.items td.td-icon {
+    max-width: 30px;
+    min-width: initial;
+  }
+  
+  .table.items td.td-amount {
+    max-width: 200px;
+    text-align: right;
+  }
+  
+  .table.items td.td-amount .form-control {
+    text-align: right;
+  }
+  
+  .table.items td.td-textarea {
+    min-width: 300px;
+    max-width: 400px;
+  }
+  
+  .table.items td.td-quantity {
+    max-width: 200px;
+  }
+  
+  .table.items td.td-vert-middle {
+    vertical-align: middle !important;
+  }
+  
+  .table .input-group {
+    width: 100%;
+    height: 100%;
+  }
+  
+  .table .input-group-addon {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+  }
+  
+  .table-responsive {
+    margin-bottom: 0;
+  }
+  
+  #item_table td,
+  #item_table th {
+    padding: 0.1875rem;
+  }
+  
+  #item_table .form-control {
+    margin: 0;
+  }
+  
+  #item_table tr.item input,
+  #item_table tr.item textarea {
+    border-color: #e5e5e5;
+    border-radius: 0;
+    box-shadow: none;
+  }
+  
+  div#item_table textarea {
+    height: 13.5rem;
+  }
+  
+  /* Navigation enhancements */
+  .navbar .navbar-collapse {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  
+  .navbar .navbar-toggle {
+    padding: 0.375rem 0.5rem;
+    color: #9d9d9d;
+    border-color: #333;
+  }
+  
+  .navbar .navbar-toggle:hover {
+    color: white;
+    border-color: #333;
+  }
+  
+  .navbar .navbar-form {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  
+  .navbar .navbar-nav .fa {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+  
+  .navbar-inner {
+    border-radius: 0;
+    padding: 0;
+    border: none;
+    text-align: right;
+  }
+  
+  /* Headerbar */
+  #headerbar {
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid #ddd;
+  }
+  
+  .headerbar-title {
+    display: inline-block;
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: normal;
+  }
+  
+  .headerbar-item {
+    display: inline-block;
+  }
+  
+  /* InvoicePlane specific components */
+  .quick-actions {
+    margin-bottom: 1rem;
+    padding: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 0.25rem;
+  }
+  
+  /* Custom item table styles */
+  #item_table .input-group {
+    padding-bottom: 0.5rem;
+  }
+  
+  #item_table .ig-addon-aligned {
+    width: 10rem;
+    text-align: right;
+  }
+  
+  #item_table select {
+    padding-left: 0.375rem;
+  }
+  
+  /* Margin utilities */
+  .mb-1 {
+    margin-bottom: 0.5rem;
+  }
+  
+  /* QR Code table */
+  table.invoice-qr-code-table {
+    width: 100%;
+    line-height: 1.4;
+    font-size: 14px;
+  }
+  
+  img#invoice-qr-code {
+    width: 200px;
+    height: auto;
+  }
+  
+  /* Stamp styles */
+  .stamp {
+    position: relative;
+    display: inline-block;
+  }
+  
+  .stamp-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-weight: bold;
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    opacity: 0.5;
+  }
+}

--- a/resources/assets/invoiceplane_blue/css/.gitignore
+++ b/resources/assets/invoiceplane_blue/css/.gitignore
@@ -1,4 +1,5 @@
 *
 !custom.css
 !custom-pdf.css
+!style-tailwind.css
 !.gitignore

--- a/resources/assets/invoiceplane_blue/css/style-tailwind.css
+++ b/resources/assets/invoiceplane_blue/css/style-tailwind.css
@@ -1,0 +1,737 @@
+/**
+ * InvoicePlane Styles - Blue Theme
+ * 
+ * This is the blue-themed InvoicePlane stylesheet that combines:
+ * 1. Tailwind CSS base, components, and utilities
+ * 2. Bootstrap-compatible classes implemented with Tailwind
+ * 3. InvoicePlane custom styles
+ */
+
+@import "tailwindcss";
+
+/* ================================
+ * InvoicePlane Color Variables
+ * Based on Bootstrap default palette
+ * ================================ */
+:root {
+  /* Gray scale - Standard Bootstrap */
+  --gray-base: #000;
+  --gray-darker: #222;
+  --gray-dark: #333;
+  --gray: #555;
+  --gray-light: #777;
+  --gray-lighter: #eee;
+  --gray-lightest: #f9f9f9;
+
+  /* Brand colors - InvoicePlane palette */
+  --brand-primary: #2C8EDD;
+  --brand-success: #5cb85c;
+  --brand-info: #5bc0de;
+  --brand-warning: #f0ad4e;
+  --brand-danger: #d9534f;
+
+  /* Dark variants for alerts */
+  --dark-success: #3c763d;
+  --dark-info: #31708f;
+  --dark-warning: #8a6d3b;
+  --dark-danger: #a94442;
+
+  /* Scaffolding */
+  --body-bg: #fff;
+  --text-color: #333;
+  --link-color: #2C8EDD;
+  --link-hover-color: #1a6bb8;
+}
+
+@layer components {
+  /* ================================
+   * BUTTONS
+   * ================================ */
+  
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25rem;
+    border-radius: 0.25rem;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background-color 150ms ease-in-out, border-color 150ms ease-in-out;
+  }
+  
+  .btn-primary {
+    background-color: var(--brand-primary);
+    color: white;
+    border-color: #2579c4;
+  }
+  
+  .btn-primary:hover {
+    background-color: #2579c4;
+    border-color: #1e68a8;
+  }
+  
+  .btn-default {
+    background-color: white;
+    color: var(--gray-darker);
+    border-color: #ccc;
+  }
+  
+  .btn-default:hover {
+    background-color: var(--gray-lighter);
+    border-color: #adadad;
+  }
+  
+  .btn-success {
+    background-color: var(--brand-success);
+    color: white;
+    border-color: #4cae4c;
+  }
+  
+  .btn-success:hover {
+    background-color: #449d44;
+    border-color: #398439;
+  }
+  
+  .btn-info {
+    background-color: var(--brand-info);
+    color: white;
+    border-color: #46b8da;
+  }
+  
+  .btn-info:hover {
+    background-color: #31b0d5;
+    border-color: #269abc;
+  }
+  
+  .btn-warning {
+    background-color: var(--brand-warning);
+    color: white;
+    border-color: #eea236;
+  }
+  
+  .btn-warning:hover {
+    background-color: #ec971f;
+    border-color: #d58512;
+  }
+  
+  .btn-danger {
+    background-color: var(--brand-danger);
+    color: white;
+    border-color: #d43f3a;
+  }
+  
+  .btn-danger:hover {
+    background-color: #c9302c;
+    border-color: #ac2925;
+  }
+  
+  /* Button sizes */
+  .btn-xs {
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+  
+  .btn-sm {
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+  
+  .btn-lg {
+    padding: 0.625rem 1rem;
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+  
+  .btn-block {
+    width: 100%;
+    display: block;
+  }
+  
+  /* ================================
+   * FORMS
+   * ================================ */
+  
+  .form-group {
+    margin-bottom: 1rem;
+  }
+  
+  .form-control {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.25;
+    color: var(--gray);
+    background-color: white;
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    transition: border-color 150ms ease-in-out, box-shadow 150ms ease-in-out;
+  }
+  
+  .form-control:focus {
+    border-color: #66afe9;
+    outline: none;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  }
+  
+  .input-sm {
+    height: 30px;
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+  
+  .input-lg {
+    height: 46px;
+    padding: 0.625rem 1rem;
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+  
+  .input-group {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+  }
+  
+  .input-group-addon {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: normal;
+    line-height: 1.25;
+    color: var(--gray);
+    text-align: center;
+    background-color: var(--gray-lighter);
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    white-space: nowrap;
+  }
+  
+  label {
+    display: inline-block;
+    max-width: 100%;
+    margin-bottom: 0.25rem;
+    font-weight: normal;
+  }
+  
+  /* ================================
+   * TABLES
+   * ================================ */
+  
+  .table {
+    width: 100%;
+    margin-bottom: 1.25rem;
+    border-collapse: collapse;
+  }
+  
+  .table > thead > tr > th,
+  .table > tbody > tr > th,
+  .table > tfoot > tr > th,
+  .table > thead > tr > td,
+  .table > tbody > tr > td,
+  .table > tfoot > tr > td {
+    padding: 0.5rem;
+    line-height: 1.25;
+    border-top: 1px solid #ddd;
+  }
+  
+  .table > thead > tr > th {
+    border-bottom: 2px solid #ddd;
+    vertical-align: bottom;
+  }
+  
+  .table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: var(--gray-lightest);
+  }
+  
+  .table-bordered {
+    border: 1px solid #ddd;
+  }
+  
+  .table-bordered > thead > tr > th,
+  .table-bordered > tbody > tr > th,
+  .table-bordered > tfoot > tr > th,
+  .table-bordered > thead > tr > td,
+  .table-bordered > tbody > tr > td,
+  .table-bordered > tfoot > tr > td {
+    border: 1px solid #ddd;
+  }
+  
+  .table-hover > tbody > tr:hover {
+    background-color: #f5f5f5;
+  }
+  
+  /* ================================
+   * ALERTS
+   * ================================ */
+  
+  .alert {
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.25rem;
+    border: 1px solid;
+    border-radius: 0.25rem;
+  }
+  
+  .alert-success {
+    color: var(--dark-success);
+    background-color: #dff0d8;
+    border-color: #d6e9c6;
+  }
+  
+  .alert-info {
+    color: var(--dark-info);
+    background-color: #d9edf7;
+    border-color: #bce8f1;
+  }
+  
+  .alert-warning {
+    color: var(--dark-warning);
+    background-color: #fcf8e3;
+    border-color: #faebcc;
+  }
+  
+  .alert-danger {
+    color: var(--dark-danger);
+    background-color: #f2dede;
+    border-color: #ebccd1;
+  }
+  
+  /* ================================
+   * PANELS
+   * ================================ */
+  
+  .panel {
+    margin-bottom: 1.25rem;
+    background-color: white;
+    border: 1px solid #ddd;
+    border-radius: 0.25rem;
+  }
+  
+  .panel-body {
+    padding: 1rem;
+  }
+  
+  .panel-heading {
+    padding: 0.625rem 1rem;
+    border-bottom: 1px solid #ddd;
+  }
+  
+  .panel-default > .panel-heading {
+    color: var(--gray-darker);
+    background-color: #f5f5f5;
+    border-color: #ddd;
+  }
+  
+  /* ================================
+   * UTILITIES
+   * ================================ */
+  
+  .pull-left {
+    float: left;
+  }
+  
+  .pull-right {
+    float: right;
+  }
+  
+  .text-left {
+    text-align: left;
+  }
+  
+  .text-center {
+    text-align: center;
+  }
+  
+  .text-right {
+    text-align: right;
+  }
+  
+  .text-muted {
+    color: #777;
+  }
+  
+  .clearfix::after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+  
+  /* ================================
+   * PAGINATION
+   * ================================ */
+  
+  .pagination {
+    display: flex;
+    list-style: none;
+    border-radius: 0.25rem;
+    padding-left: 0;
+    margin-bottom: 1.25rem;
+  }
+  
+  .pagination > li > a,
+  .pagination > li > span {
+    position: relative;
+    float: left;
+    padding: 0.375rem 0.75rem;
+    line-height: 1.25;
+    color: var(--brand-primary);
+    text-decoration: none;
+    background-color: white;
+    border: 1px solid #ddd;
+    margin-left: -1px;
+  }
+  
+  .pagination > li:first-child > a,
+  .pagination > li:first-child > span {
+    margin-left: 0;
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
+  }
+  
+  .pagination > li:last-child > a,
+  .pagination > li:last-child > span {
+    border-top-right-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+  }
+  
+  .pagination > li > a:hover {
+    background-color: var(--gray-lighter);
+    border-color: #ddd;
+  }
+  
+  .pagination > .active > a {
+    z-index: 10;
+    color: white;
+    background-color: var(--brand-primary);
+    border-color: var(--brand-primary);
+    cursor: default;
+  }
+}
+
+/* Import Tailwind CSS and Bootstrap-compatible classes */
+
+/* Import third-party component styles that don't need refactoring */
+@import "bootstrap-datepicker/dist/css/bootstrap-datepicker3.css";
+@import "font-awesome/css/font-awesome.css";
+@import "dropzone/dist/dropzone.css";
+@import "select2/dist/css/select2.css";
+
+/* Import existing custom CSS files */
+@import "../../core/css/custom.css";
+
+/* ================================
+ * InvoicePlane Core Styles
+ * Using Tailwind's @layer to add custom components
+ * ================================ */
+
+@layer components {
+  /* Fix for Bootstrap 3 collapse table behavior */
+  table.collapse.in {
+    display: table;
+  }
+  
+  /* Alert fix for CI core paragraph */
+  .alert-dismissible p {
+    display: inline;
+  }
+  
+  /* Base HTML styles */
+  html {
+    min-height: 100vh;
+  }
+  
+  body {
+    min-height: 100vh;
+    overflow-x: hidden;
+    overflow-y: scroll;
+  }
+  
+  img {
+    vertical-align: middle;
+    max-width: 100%;
+  }
+  
+  h1, h2, h3, h4, h5, h6 {
+    margin: 0;
+  }
+  
+  /* Text ellipsis helpers */
+  .dib {
+    display: inline-block;
+  }
+  
+  .db {
+    display: block;
+  }
+  
+  .te {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 160px;
+  }
+  
+  /* Variable width text ellipsis */
+  .te.te-1 { max-width: 10vw; }
+  .te.te-2 { max-width: 20vw; }
+  .te.te-3 { max-width: 30vw; }
+  .te.te-4 { max-width: 40vw; }
+  .te.te-5 { max-width: 50vw; }
+  .te.te-6 { max-width: 60vw; }
+  .te.te-7 { max-width: 70vw; }
+  .te.te-8 { max-width: 80vw; }
+  .te.te-9 { max-width: 90vw; }
+  
+  /* Dropzone mobile-first */
+  #previews .name {
+    word-wrap: anywhere;
+  }
+  
+  /* Forms */
+  form {
+    margin: 0;
+  }
+  
+  fieldset {
+    border-radius: 0.25rem;
+    border: 1px solid #ddd;
+    margin-bottom: 1rem;
+    padding: 1rem;
+  }
+  
+  fieldset legend {
+    padding: 0 1rem;
+    font-size: 1.125rem;
+    width: auto;
+    border: none;
+    margin: 0;
+  }
+  
+  label {
+    font-weight: normal;
+  }
+  
+  textarea {
+    resize: vertical;
+  }
+  
+  .discount-field {
+    float: right;
+    max-width: 40%;
+    margin-left: 0.625rem;
+  }
+  
+  .discount-field .input-sm {
+    height: auto;
+    padding: 0.125rem 0.25rem;
+  }
+  
+  .discount-field .input-group-addon {
+    min-width: 20px;
+  }
+  
+  .optional {
+    float: right;
+    font-size: small;
+    color: #777;
+  }
+  
+  /* Enhanced table styles */
+  .table {
+    margin: 0 0 1rem;
+    font-size: 0.875rem;
+  }
+  
+  .table.no-margin {
+    margin: 0;
+  }
+  
+  .table td {
+    vertical-align: middle !important;
+  }
+  
+  .table tr.bold-border td {
+    border-bottom-width: 2px;
+  }
+  
+  .table.items td {
+    min-width: 150px;
+    max-width: 300px;
+    vertical-align: top !important;
+  }
+  
+  .table.items td.td-icon {
+    max-width: 30px;
+    min-width: initial;
+  }
+  
+  .table.items td.td-amount {
+    max-width: 200px;
+    text-align: right;
+  }
+  
+  .table.items td.td-amount .form-control {
+    text-align: right;
+  }
+  
+  .table.items td.td-textarea {
+    min-width: 300px;
+    max-width: 400px;
+  }
+  
+  .table.items td.td-quantity {
+    max-width: 200px;
+  }
+  
+  .table.items td.td-vert-middle {
+    vertical-align: middle !important;
+  }
+  
+  .table .input-group {
+    width: 100%;
+    height: 100%;
+  }
+  
+  .table .input-group-addon {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+  }
+  
+  .table-responsive {
+    margin-bottom: 0;
+  }
+  
+  #item_table td,
+  #item_table th {
+    padding: 0.1875rem;
+  }
+  
+  #item_table .form-control {
+    margin: 0;
+  }
+  
+  #item_table tr.item input,
+  #item_table tr.item textarea {
+    border-color: #e5e5e5;
+    border-radius: 0;
+    box-shadow: none;
+  }
+  
+  div#item_table textarea {
+    height: 13.5rem;
+  }
+  
+  /* Navigation enhancements */
+  .navbar .navbar-collapse {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  
+  .navbar .navbar-toggle {
+    padding: 0.375rem 0.5rem;
+    color: #9d9d9d;
+    border-color: #333;
+  }
+  
+  .navbar .navbar-toggle:hover {
+    color: white;
+    border-color: #333;
+  }
+  
+  .navbar .navbar-form {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  
+  .navbar .navbar-nav .fa {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+  
+  .navbar-inner {
+    border-radius: 0;
+    padding: 0;
+    border: none;
+    text-align: right;
+  }
+  
+  /* Headerbar */
+  #headerbar {
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid #ddd;
+  }
+  
+  .headerbar-title {
+    display: inline-block;
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: normal;
+  }
+  
+  .headerbar-item {
+    display: inline-block;
+  }
+  
+  /* InvoicePlane specific components */
+  .quick-actions {
+    margin-bottom: 1rem;
+    padding: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 0.25rem;
+  }
+  
+  /* Custom item table styles */
+  #item_table .input-group {
+    padding-bottom: 0.5rem;
+  }
+  
+  #item_table .ig-addon-aligned {
+    width: 10rem;
+    text-align: right;
+  }
+  
+  #item_table select {
+    padding-left: 0.375rem;
+  }
+  
+  /* Margin utilities */
+  .mb-1 {
+    margin-bottom: 0.5rem;
+  }
+  
+  /* QR Code table */
+  table.invoice-qr-code-table {
+    width: 100%;
+    line-height: 1.4;
+    font-size: 14px;
+  }
+  
+  img#invoice-qr-code {
+    width: 200px;
+    height: auto;
+  }
+  
+  /* Stamp styles */
+  .stamp {
+    position: relative;
+    display: inline-block;
+  }
+  
+  .stamp-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-weight: bold;
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    opacity: 0.5;
+  }
+}

--- a/resources/assets/nord/css/style-tailwind.css
+++ b/resources/assets/nord/css/style-tailwind.css
@@ -1,0 +1,1008 @@
+/**
+ * InvoicePlane Styles - Nord Theme
+ * 
+ * This is the Nord-themed stylesheet that combines:
+ * 1. Tailwind CSS base, components, and utilities with Nord color palette
+ * 2. Bootstrap-compatible classes implemented with Tailwind
+ * 3. InvoicePlane custom styles with Nord theming
+ */
+
+@import "tailwindcss";
+
+/* ================================
+ * Nord Color Variables
+ * Based on the Nord color palette
+ * ================================ */
+:root {
+  /* Gray scale - Nord Polar Night & Snow Storm */
+  --gray-base: #4C566A;
+  --gray-darker: #2E3440;
+  --gray-dark: #3B4252;
+  --gray: #4C566A;
+  --gray-light: #d8dee9;
+  --gray-lighter: #eceff4;
+  --gray-lightest: #e5e9f0;
+
+  /* Brand colors - Nord palette */
+  --brand-primary: #4C566A;
+  --brand-success: #8FBCBB;
+  --dark-success: #052e16;
+  --brand-info: #88C0D0;
+  --dark-info: #082f49;
+  --ivpl-info: #54a0c6;
+  --brand-warning: #EBCB8B;
+  --dark-warning: #8a6d3b;
+  --brand-danger: #BF616A;
+  --dark-danger: #450a0a;
+
+  /* Scaffolding */
+  --body-bg: #4C566A;
+  --text-color: #d8dee9;
+  --link-color: #d8dee9;
+  --link-hover-color: #eceff4;
+}
+
+@layer components {
+  /* ================================
+   * BUTTONS
+   * ================================ */
+  
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25rem;
+    border-radius: 0.25rem;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background-color 150ms ease-in-out, border-color 150ms ease-in-out;
+  }
+  
+  .btn-primary {
+    background-color: var(--brand-primary);
+    color: var(--gray-lightest);
+    border-color: var(--gray-dark);
+  }
+  
+  .btn-primary:hover {
+    background-color: var(--gray-dark);
+    border-color: var(--gray-darker);
+  }
+  
+  .btn-default {
+    background-color: var(--gray-lightest);
+    color: var(--gray-darker);
+    border-color: var(--gray-light);
+  }
+  
+  .btn-default:hover {
+    background-color: var(--gray-lighter);
+    border-color: var(--gray);
+  }
+  
+  .btn-success {
+    background-color: var(--brand-success);
+    color: white;
+    border-color: #7aafae;
+  }
+  
+  .btn-success:hover {
+    background-color: #7aafae;
+    border-color: #6a9f9e;
+  }
+  
+  .btn-info {
+    background-color: var(--brand-info);
+    color: white;
+    border-color: #76b3c3;
+  }
+  
+  .btn-info:hover {
+    background-color: #76b3c3;
+    border-color: #64a6b6;
+  }
+  
+  .btn-warning {
+    background-color: var(--brand-warning);
+    color: var(--gray-darker);
+    border-color: #e5c078;
+  }
+  
+  .btn-warning:hover {
+    background-color: #e5c078;
+    border-color: #deb565;
+  }
+  
+  .btn-danger {
+    background-color: var(--brand-danger);
+    color: white;
+    border-color: #b3545d;
+  }
+  
+  .btn-danger:hover {
+    background-color: #b3545d;
+    border-color: #a64850;
+  }
+  
+  /* Button sizes */
+  .btn-xs {
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+  
+  .btn-sm {
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+  
+  .btn-lg {
+    padding: 0.625rem 1rem;
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+  
+  .btn-block {
+    width: 100%;
+    display: block;
+  }
+  
+  /* ================================
+   * FORMS
+   * ================================ */
+  
+  .form-group {
+    margin-bottom: 1rem;
+  }
+  
+  .form-control {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.25;
+    color: var(--gray);
+    background-color: white;
+    border: 1px solid var(--gray-light);
+    border-radius: 0.25rem;
+    transition: border-color 150ms ease-in-out, box-shadow 150ms ease-in-out;
+  }
+  
+  .form-control:focus {
+    border-color: var(--brand-info);
+    outline: none;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(136, 192, 208, 0.6);
+  }
+  
+  .input-sm {
+    height: 30px;
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+  }
+  
+  .input-lg {
+    height: 46px;
+    padding: 0.625rem 1rem;
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+  
+  .input-group {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+  }
+  
+  .input-group-addon {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: normal;
+    line-height: 1.25;
+    color: var(--gray);
+    text-align: center;
+    background-color: var(--gray-lighter);
+    border: 1px solid var(--gray-light);
+    border-radius: 0.25rem;
+    white-space: nowrap;
+  }
+  
+  label {
+    display: inline-block;
+    max-width: 100%;
+    margin-bottom: 0.25rem;
+    font-weight: normal;
+  }
+  
+  /* ================================
+   * TABLES
+   * ================================ */
+  
+  .table {
+    width: 100%;
+    margin-bottom: 1.25rem;
+    border-collapse: collapse;
+  }
+  
+  .table > thead > tr > th,
+  .table > tbody > tr > th,
+  .table > tfoot > tr > th,
+  .table > thead > tr > td,
+  .table > tbody > tr > td,
+  .table > tfoot > tr > td {
+    padding: 0.5rem;
+    line-height: 1.25;
+    border-top: 1px solid var(--gray-light);
+  }
+  
+  .table > thead > tr > th {
+    border-bottom: 2px solid var(--gray-light);
+    vertical-align: bottom;
+  }
+  
+  .table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: var(--gray-lightest);
+  }
+  
+  .table-bordered {
+    border: 1px solid var(--gray-light);
+  }
+  
+  .table-bordered > thead > tr > th,
+  .table-bordered > tbody > tr > th,
+  .table-bordered > tfoot > tr > th,
+  .table-bordered > thead > tr > td,
+  .table-bordered > tbody > tr > td,
+  .table-bordered > tfoot > tr > td {
+    border: 1px solid var(--gray-light);
+  }
+  
+  .table-hover > tbody > tr:hover {
+    background-color: var(--gray-lightest);
+  }
+  
+  /* ================================
+   * ALERTS
+   * ================================ */
+  
+  .alert {
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.25rem;
+    border: 1px solid;
+    border-radius: 0.25rem;
+  }
+  
+  .alert-success {
+    color: var(--dark-success);
+    background-color: #d8f5f0;
+    border-color: #c3ede5;
+  }
+  
+  .alert-info {
+    color: var(--dark-info);
+    background-color: #daf2f8;
+    border-color: #c5ebf4;
+  }
+  
+  .alert-warning {
+    color: var(--dark-warning);
+    background-color: #fdf8e8;
+    border-color: #fbf2d4;
+  }
+  
+  .alert-danger {
+    color: var(--dark-danger);
+    background-color: #f8e3e5;
+    border-color: #f2d3d6;
+  }
+  
+  /* ================================
+   * PANELS
+   * ================================ */
+  
+  .panel {
+    margin-bottom: 1.25rem;
+    background-color: white;
+    border: 1px solid var(--gray-light);
+    border-radius: 0.25rem;
+  }
+  
+  .panel-body {
+    padding: 1rem;
+  }
+  
+  .panel-heading {
+    padding: 0.625rem 1rem;
+    border-bottom: 1px solid var(--gray-light);
+  }
+  
+  .panel-default > .panel-heading {
+    color: var(--gray-darker);
+    background-color: var(--gray-lightest);
+    border-color: var(--gray-light);
+  }
+  
+  /* ================================
+   * UTILITIES
+   * ================================ */
+  
+  .pull-left {
+    float: left;
+  }
+  
+  .pull-right {
+    float: right;
+  }
+  
+  .text-left {
+    text-align: left;
+  }
+  
+  .text-center {
+    text-align: center;
+  }
+  
+  .text-right {
+    text-align: right;
+  }
+  
+  .text-muted {
+    color: #777;
+  }
+  
+  .clearfix::after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+  
+  /* ================================
+   * PAGINATION
+   * ================================ */
+  
+  .pagination {
+    display: flex;
+    list-style: none;
+    border-radius: 0.25rem;
+    padding-left: 0;
+    margin-bottom: 1.25rem;
+  }
+  
+  .pagination > li > a,
+  .pagination > li > span {
+    position: relative;
+    float: left;
+    padding: 0.375rem 0.75rem;
+    line-height: 1.25;
+    color: var(--brand-primary);
+    text-decoration: none;
+    background-color: white;
+    border: 1px solid var(--gray-light);
+    margin-left: -1px;
+  }
+  
+  .pagination > li:first-child > a,
+  .pagination > li:first-child > span {
+    margin-left: 0;
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
+  }
+  
+  .pagination > li:last-child > a,
+  .pagination > li:last-child > span {
+    border-top-right-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+  }
+  
+  .pagination > li > a:hover {
+    background-color: var(--gray-lighter);
+    border-color: var(--gray-light);
+  }
+  
+  .pagination > .active > a {
+    z-index: 10;
+    color: white;
+    background-color: var(--brand-primary);
+    border-color: var(--brand-primary);
+    cursor: default;
+  }
+}
+
+/* Import Tailwind CSS and Bootstrap-compatible classes */
+
+/* Import third-party component styles that don't need refactoring */
+@import "bootstrap-datepicker/dist/css/bootstrap-datepicker3.css";
+@import "font-awesome/css/font-awesome.css";
+@import "dropzone/dist/dropzone.css";
+@import "select2/dist/css/select2.css";
+
+/* Import existing custom CSS files */
+@import "../../core/css/custom.css";
+
+/* ================================
+ * Nord Color Palette Theme
+ * Tailwind v4 CSS tokens
+ * ================================ */
+
+@theme {
+    --color-secondary-50: #E3E9F0;
+    --color-secondary-100: #D1D7E0;
+    --color-secondary-200: #A7B1C5;
+    --color-secondary-300: #8C9AB3;
+    --color-secondary-400: #71829B;
+    --color-secondary-500: #5E81AC;
+    --color-secondary-600: #527397;
+    --color-secondary-700: #466582;
+    --color-secondary-800: #3A576D;
+    --color-secondary-900: #2E4958;
+    --color-secondary-950: #223B43;
+
+    /* Polar Night: Used for dark backgrounds and text */
+    --color-polarnight-50: #e5e9f0;
+    --color-polarnight-100: #d1d7e0;
+    --color-polarnight-200: #a7b1c5;
+    --color-polarnight-300: #8c9ab3;
+    --color-polarnight-400: #71829b;
+    --color-polarnight-500: #4c566a;
+    --color-polarnight-600: #434c5e;
+    --color-polarnight-700: #3b4252;
+    --color-polarnight-800: #2e3440;
+    --color-polarnight-900: #232831;
+    --color-polarnight-950: #1b2027;
+
+    /* Snow Storm: Used for light backgrounds and text */
+    --color-snowstorm-400: #d8dee9;
+    --color-snowstorm-500: #e5e9f0;
+    --color-snowstorm-600: #eceff4;
+
+    /* Frost: Used for primary and secondary accents */
+    --color-frost-400: #8fbcbb;
+    --color-frost-500: #88c0d0;
+    --color-frost-600: #81a1c1;
+    --color-frost-700: #5e81ac;
+
+    /* Aurora: Used for success, warning, etc. */
+    --color-aurora-danger: #bf616a;
+    --color-aurora-warning: #ebcb8b;
+    --color-aurora-success: #a3be8c;
+    --color-aurora-info: #81a1c1;
+    --color-aurora-purple: #b48ead;
+    --color-aurora-orange: #d08770;
+
+    /* Semantic color mapping to Nord palette */
+    --color-danger: var(--color-aurora-danger);
+    --color-warning: var(--color-aurora-warning);
+    --color-success: var(--color-aurora-success);
+    --color-info: var(--color-aurora-info);
+
+    /* Main theme colors from the Frost palette */
+    --color-primary: var(--color-frost-500);
+    --color-primary-100: #E5F3F7;
+    --color-primary-200: #CCE7EF;
+    --color-primary-300: #B3DBE7;
+    --color-primary-400: var(--color-frost-400);
+    --color-primary-500: var(--color-frost-500);
+    --color-primary-600: var(--color-frost-600);
+    --color-primary-700: var(--color-frost-700);
+    --color-primary-800: var(--color-frost-700);
+    --color-primary-900: var(--color-polarnight-800);
+    --color-primary-950: var(--color-polarnight-900);
+
+    /* General UI colors from Polarnight & Snowstorm */
+    --color-background-light: var(--color-snowstorm-500);
+    --color-background-dark: var(--color-polarnight-800);
+    --color-surface-light: var(--color-snowstorm-600);
+    --color-surface-dark: var(--color-polarnight-700);
+    --color-text-dark: var(--color-polarnight-600);
+    --color-text-light: var(--color-snowstorm-500);
+    --color-text-subtle: var(--color-polarnight-500);
+    --color-border-light: var(--color-snowstorm-400);
+    --color-border-dark: var(--color-polarnight-700);
+}
+
+/* ================================
+ * InvoicePlane Core Styles
+ * Using Tailwind's @layer to add custom components
+ * ================================ */
+
+@layer components {
+  /* Fix for Bootstrap 3 collapse table behavior */
+  table.collapse.in {
+    display: table;
+  }
+  
+  /* Alert fix for CI core paragraph */
+  .alert-dismissible p {
+    display: inline;
+  }
+  
+  /* Base HTML styles */
+  html {
+    min-height: 100vh;
+  }
+  
+  body {
+    min-height: 100vh;
+    overflow-x: hidden;
+    overflow-y: scroll;
+  }
+  
+  img {
+    vertical-align: middle;
+    max-width: 100%;
+  }
+  
+  h1, h2, h3, h4, h5, h6 {
+    margin: 0;
+  }
+  
+  /* Text ellipsis helpers */
+  .dib {
+    display: inline-block;
+  }
+  
+  .db {
+    display: block;
+  }
+  
+  .te {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 160px;
+  }
+  
+  /* Variable width text ellipsis */
+  .te.te-1 { max-width: 10vw; }
+  .te.te-2 { max-width: 20vw; }
+  .te.te-3 { max-width: 30vw; }
+  .te.te-4 { max-width: 40vw; }
+  .te.te-5 { max-width: 50vw; }
+  .te.te-6 { max-width: 60vw; }
+  .te.te-7 { max-width: 70vw; }
+  .te.te-8 { max-width: 80vw; }
+  .te.te-9 { max-width: 90vw; }
+  
+  /* Dropzone mobile-first */
+  #previews .name {
+    word-wrap: anywhere;
+  }
+  
+  /* Forms */
+  form {
+    margin: 0;
+  }
+  
+  fieldset {
+    border-radius: 0.25rem;
+    border: 1px solid #ddd;
+    margin-bottom: 1rem;
+    padding: 1rem;
+  }
+  
+  fieldset legend {
+    padding: 0 1rem;
+    font-size: 1.125rem;
+    width: auto;
+    border: none;
+    margin: 0;
+  }
+  
+  label {
+    font-weight: normal;
+  }
+  
+  textarea {
+    resize: vertical;
+  }
+  
+  .discount-field {
+    float: right;
+    max-width: 40%;
+    margin-left: 0.625rem;
+  }
+  
+  .discount-field .input-sm {
+    height: auto;
+    padding: 0.125rem 0.25rem;
+  }
+  
+  .discount-field .input-group-addon {
+    min-width: 20px;
+  }
+  
+  .optional {
+    float: right;
+    font-size: small;
+    color: #777;
+  }
+  
+  /* Enhanced table styles */
+  .table {
+    margin: 0 0 1rem;
+    font-size: 0.875rem;
+  }
+  
+  .table.no-margin {
+    margin: 0;
+  }
+  
+  .table td {
+    vertical-align: middle !important;
+  }
+  
+  .table tr.bold-border td {
+    border-bottom-width: 2px;
+  }
+  
+  .table.items td {
+    min-width: 150px;
+    max-width: 300px;
+    vertical-align: top !important;
+  }
+  
+  .table.items td.td-icon {
+    max-width: 30px;
+    min-width: initial;
+  }
+  
+  .table.items td.td-amount {
+    max-width: 200px;
+    text-align: right;
+  }
+  
+  .table.items td.td-amount .form-control {
+    text-align: right;
+  }
+  
+  .table.items td.td-textarea {
+    min-width: 300px;
+    max-width: 400px;
+  }
+  
+  .table.items td.td-quantity {
+    max-width: 200px;
+  }
+  
+  .table.items td.td-vert-middle {
+    vertical-align: middle !important;
+  }
+  
+  .table .input-group {
+    width: 100%;
+    height: 100%;
+  }
+  
+  .table .input-group-addon {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+  }
+  
+  .table-responsive {
+    margin-bottom: 0;
+  }
+  
+  #item_table td,
+  #item_table th {
+    padding: 0.1875rem;
+  }
+  
+  #item_table .form-control {
+    margin: 0;
+  }
+  
+  #item_table tr.item input,
+  #item_table tr.item textarea {
+    border-color: #e5e5e5;
+    border-radius: 0;
+    box-shadow: none;
+  }
+  
+  div#item_table textarea {
+    height: 13.5rem;
+  }
+  
+  /* Navigation enhancements */
+  .navbar .navbar-collapse {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  
+  .navbar .navbar-toggle {
+    padding: 0.375rem 0.5rem;
+    color: #9d9d9d;
+    border-color: #333;
+  }
+  
+  .navbar .navbar-toggle:hover {
+    color: white;
+    border-color: #333;
+  }
+  
+  .navbar .navbar-form {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  
+  .navbar .navbar-nav .fa {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+  
+  .navbar-inner {
+    border-radius: 0;
+    padding: 0;
+    border: none;
+    text-align: right;
+  }
+  
+  /* Headerbar */
+  #headerbar {
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid #ddd;
+  }
+  
+  .headerbar-title {
+    display: inline-block;
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: normal;
+  }
+  
+  .headerbar-item {
+    display: inline-block;
+  }
+  
+  /* InvoicePlane specific components */
+  .quick-actions {
+    margin-bottom: 1rem;
+    padding: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 0.25rem;
+  }
+  
+  /* Custom item table styles */
+  #item_table .input-group {
+    padding-bottom: 0.5rem;
+  }
+  
+  #item_table .ig-addon-aligned {
+    width: 10rem;
+    text-align: right;
+  }
+  
+  #item_table select {
+    padding-left: 0.375rem;
+  }
+  
+  /* Margin utilities */
+  .mb-1 {
+    margin-bottom: 0.5rem;
+  }
+  
+  /* QR Code table */
+  table.invoice-qr-code-table {
+    width: 100%;
+    line-height: 1.4;
+    font-size: 14px;
+  }
+  
+  img#invoice-qr-code {
+    width: 200px;
+    height: auto;
+  }
+  
+  /* Stamp styles */
+  .stamp {
+    position: relative;
+    display: inline-block;
+  }
+  
+  .stamp-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-weight: bold;
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    opacity: 0.5;
+  }
+
+  /* ================================
+   * Nord Theme Component Styles
+   * Filament-inspired design language
+   * ================================ */
+
+  /* Layout and backgrounds */
+  .fi-layout {
+    @apply bg-[var(--color-background-light)] dark:bg-[var(--color-background-dark)];
+  }
+
+  .fi-topbar nav, .fi-sidebar-header {
+    @apply bg-[var(--color-background-light)] dark:bg-[var(--color-background-dark)];
+  }
+
+  .fi-body {
+    @apply bg-[var(--color-snowstorm-500)] dark:bg-polarnight-900;
+  }
+
+  /* Buttons */
+  .fi-btn-color-primary {
+    @apply bg-[var(--color-primary-500)];
+  }
+
+  .fi-btn:not(.fi-btn-group .fi-btn) {
+    @apply rounded-full;
+  }
+
+  .fi-btn-group > .fi-btn:first-of-type {
+    @apply rounded-s-full;
+  }
+
+  .fi-btn-group > .fi-btn:last-of-type {
+    @apply rounded-e-full;
+  }
+
+  .fi-btn-group {
+    @apply rounded-full;
+  }
+
+  .fi-btn.fi-color-primary .fi-btn-label {
+    @apply text-primary-950;
+  }
+
+  /* Tables */
+  .fi-ta-ctn, .fi-ta-ctn .fi-ta-ctn-with-header {
+    @apply dark:bg-[var(--color-surface-dark)];
+  }
+
+  .fi-ta-table thead tr {
+    @apply bg-[var(--color-surface-light)] dark:bg-[var(--color-surface-dark)];
+  }
+
+  .fi-ta-ctn {
+    @apply shadow-md rounded-2xl border-none ring-0 dark:ring-1 divide-gray-100 dark:divide-white/20;
+  }
+
+  /* Sidebar and navigation */
+  .fi-sidebar-item-label, .fi-topbar-item-label {
+    @apply dark:text-gray-400;
+  }
+
+  .fi-sidebar-item-active a svg, .fi-topbar-item-active a svg {
+    @apply text-primary-800;
+  }
+
+  .fi-sidebar-item-active a span, .fi-topbar-item-active a span {
+    @apply text-primary-800 dark:text-primary-400;
+  }
+
+  .fi-sidebar-item .fi-sidebar-item-button, .fi-topbar-item .fi-topbar-item-button {
+    @apply rounded-lg hover:bg-[var(--color-snowstorm-400)] dark:hover:bg-white/5;
+  }
+
+  .fi-sidebar-item-active .fi-sidebar-item-button, .fi-topbar-item-active .fi-topbar-item-button {
+    @apply rounded-lg bg-[var(--color-snowstorm-600)] dark:focus-visible:bg-white/5 dark:bg-white/5;
+  }
+
+  .fi-sidebar-item-button .fi-badge, .fi-topbar-item-button .fi-badge {
+    @apply bg-primary-300 dark:bg-primary-200;
+  }
+
+  .fi-sidebar-item-button .fi-badge span span, .fi-topbar-item-button .fi-badge span span {
+    @apply text-gray-700;
+  }
+
+  .fi-topbar-item-active a, .fi-topbar-item-active button {
+    @apply bg-secondary-500 hover:bg-secondary-400 dark:bg-primary-500 dark:text-secondary-500 dark:hover:bg-primary-400;
+  }
+
+  .fi-topbar-item-active svg {
+    @apply dark:text-secondary-500;
+  }
+
+  .fi-topbar .fi-tenant-menu {
+    @apply lg:!hidden;
+  }
+
+  .fi-tenant-menu {
+    @apply rounded-lg mt-4;
+  }
+
+  /* Forms */
+  .fi-fo-field-wrp-label span {
+    @apply text-[var(--color-polarnight-500)];
+  }
+
+  .fi-input-wrp {
+    @apply ring-1 ring-[var(--color-snowstorm-400)] dark:ring-white/20;
+  }
+
+  .fi-input {
+    @apply disabled:!bg-gray-50 dark:disabled:!bg-gray-800;
+  }
+
+  .fi-fo-field-wrp-error-message {
+    @apply text-[var(--color-aurora-danger)] dark:text-[var(--color-aurora-orange)];
+  }
+
+  .fi-invalid {
+    @apply ring-[var(--color-aurora-danger)] dark:ring-[var(--color-aurora-orange)];
+  }
+
+  .fi-fo-field-wrp-helper-text {
+    @apply text-gray-500 dark:text-gray-300;
+  }
+
+  /* Search fields */
+  .fi-global-search-field .fi-input-wrp, .fi-ta-search-field .fi-input-wrp {
+    @apply rounded-full bg-[var(--color-snowstorm-500)] dark:bg-gray-900;
+  }
+
+  .fi-global-search-field .fi-input-wrp {
+    @apply ring-4 ring-white dark:ring-gray-800;
+  }
+
+  .fi-global-search-field .fi-input-wrp .fi-input-wrp-prefix {
+    @apply bg-white dark:bg-gray-800 rounded-full ps-2 mr-2;
+  }
+
+  /* Breadcrumbs and headers */
+  .fi-breadcrumbs-item-label {
+    @apply text-[var(--color-polarnight-500)];
+  }
+
+  .fi-header-heading, .fi-ta-header-cell-label, .fi-btn-color-gray span {
+    @apply text-[var(--color-polarnight-600)] dark:text-[var(--color-snowstorm-500)];
+  }
+
+  /* Tabs */
+  .fi-tabs-item-active {
+    @apply bg-primary-100;
+  }
+
+  .fi-tabs-item-active span {
+    @apply !text-secondary-900 dark:!text-gray-100;
+  }
+
+  /* Sections and panels */
+  .fi-section, .fi-wi-stats-overview-stat, .fi-ta-ctn, .fi-tenant-menu, .fi-dropdown-panel {
+    @apply border border-transparent dark:bg-secondary-900;
+  }
+
+  .dark .fi-section, .dark .fi-wi-stats-overview-stat, .dark .fi-ta-ctn, .dark .fi-tenant-menu, .dark .fi-dropdown-panel {
+    background: linear-gradient(var(--color-polarnight-800), var(--color-polarnight-700)),
+    linear-gradient(to right, var(--color-secondary-800), var(--color-polarnight-700));
+    background-clip: padding-box, border-box;
+    background-origin: border-box;
+  }
+
+  .fi-section, .fi-wi-stats-overview-stat {
+    @apply shadow-md rounded-2xl border-none ring-0 dark:ring-1;
+  }
+
+  .fi-wi-widget .fi-section, .fi-wi-stats-overview-stat {
+    @apply dark:ring-gray-700 dark:hover:text-white/70 dark:hover:ring-gray-500;
+  }
+
+  /* Toggles */
+  .fi-ta-toggle > div.fi-color-custom, .fi-fo-toggle.fi-color-custom {
+    @apply bg-primary-500;
+  }
+
+  .fi-ta-toggle > div.fi-color-gray, .fi-fo-toggle.fi-color-gray {
+    @apply bg-gray-200;
+  }
+
+  /* Badges */
+  .fi-badge {
+    @apply rounded-xl;
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,8 +37,14 @@ export default defineConfig({
         // Main Tailwind CSS styles
         'core/css/style-tailwind': 'resources/assets/core/css/style-tailwind.css',
 
-        // Filament Nord theme stylesheet
-        'core/css/themes/filament-nord': 'resources/assets/core/css/themes/filament-nord.css',
+        // Nord Theme - Brand new theme with Nord color palette
+        'nord/css/style-tailwind': 'resources/assets/nord/css/style-tailwind.css',
+
+        // InvoicePlane Default Theme
+        'invoiceplane/css/style-tailwind': 'resources/assets/invoiceplane/css/style-tailwind.css',
+
+        // InvoicePlane Blue Theme
+        'invoiceplane_blue/css/style-tailwind': 'resources/assets/invoiceplane_blue/css/style-tailwind.css',
         
         // Existing custom CSS files
         'core/css/custom-pdf': 'resources/assets/core/css/custom-pdf.css',

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,6 +36,9 @@ export default defineConfig({
       input: {
         // Main Tailwind CSS styles
         'core/css/style-tailwind': 'resources/assets/core/css/style-tailwind.css',
+
+        // Filament Nord theme stylesheet
+        'core/css/themes/filament-nord': 'resources/assets/core/css/themes/filament-nord.css',
         
         // Existing custom CSS files
         'core/css/custom-pdf': 'resources/assets/core/css/custom-pdf.css',


### PR DESCRIPTION
## Summary
- add a Nord-inspired Filament theme stylesheet with Tailwind tokens and component styling
- configure Vite to output the new Nord theme into the public assets directory

## Testing
- npm run build *(fails: Missing dependency `@tailwindcss/postcss` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690576928d2483298f51f2b5e190088b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nord theme with comprehensive styling for all UI components and dark mode support.
  * Added InvoicePlane theme with Tailwind-based styling framework.
  * Added InvoicePlane Blue theme variant.

* **Style**
  * Enhanced theme system with CSS variables and semantic color mappings across buttons, forms, tables, and other components.
  * Updated build configuration to include new theme stylesheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->